### PR TITLE
RS485 Data Dropping

### DIFF
--- a/examples/RS485Deferred/RS485Deferred.ino
+++ b/examples/RS485Deferred/RS485Deferred.ino
@@ -1,0 +1,73 @@
+/*
+  The purpose of this example is to demonstrate how the Arudino Mega will drop incoming RS485 data if
+  processing is done in the ISR.
+  
+  #define DCSBIOS_DEFER_RS485_PROCESSING is enabled in this sketch, comment
+  it out to see the problem. You don't need all LED's to be physicallyconnected, just any one that is
+  supposed to be blinking.
+
+  Even though the sketch uses efficient direct register access, this sketch will still drop data and
+  not blink the LEDs in sync with the sim unless DCSBIOS_DEFER_RS485_PROCESSING is defined.
+*/
+
+#define DCSBIOS_RS485_SLAVE 23 // The following #define tells DCS-BIOS that this is a RS-485 slave device. It also sets the address of this slave device. The slave address should be between 1 and 126 and must be unique among all devices on the same bus.
+#define TXENABLE_PIN 2 // The Arduino pin that is connected to the /RE and DE pins on the RS-485 transceiver.
+#define DCSBIOS_DEFER_RS485_PROCESSING // Defer RS485 processing from the ISR to loop().
+#include "DcsBios.h"
+
+void onClA1Change(unsigned int newValue) { if (newValue == 1) { PORTE |= (1 << 5); } else { PORTE &= ~(1 << 5); } } DcsBios::IntegerBuffer clA1Buffer(0x10d4, 0x0001, 0, onClA1Change);
+void onClA2Change(unsigned int newValue) { if (newValue == 1) { PORTG |= (1 << 5); } else { PORTG &= ~(1 << 5); } } DcsBios::IntegerBuffer clA2Buffer(0x10d4, 0x0002, 1, onClA2Change);
+void onClA3Change(unsigned int newValue) { if (newValue == 1) { PORTE |= (1 << 3); } else { PORTE &= ~(1 << 3); } } DcsBios::IntegerBuffer clA3Buffer(0x10d4, 0x0004, 2, onClA3Change);
+void onClA4Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 3); } else { PORTH &= ~(1 << 3); } } DcsBios::IntegerBuffer clA4Buffer(0x10d4, 0x0008, 3, onClA4Change);
+void onClB1Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 4); } else { PORTH &= ~(1 << 4); } } DcsBios::IntegerBuffer clB1Buffer(0x10d4, 0x0010, 4, onClB1Change);
+void onClB2Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 5); } else { PORTH &= ~(1 << 5); } } DcsBios::IntegerBuffer clB2Buffer(0x10d4, 0x0020, 5, onClB2Change);
+void onClB3Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 6); } else { PORTH &= ~(1 << 6); } } DcsBios::IntegerBuffer clB3Buffer(0x10d4, 0x0040, 6, onClB3Change);
+void onClB4Change(unsigned int newValue) { if (newValue == 1) { PORTB |= (1 << 4); } else { PORTB &= ~(1 << 4); } } DcsBios::IntegerBuffer clB4Buffer(0x10d4, 0x0080, 7, onClB4Change);
+void onClC1Change(unsigned int newValue) { if (newValue == 1) { PORTB |= (1 << 5); } else { PORTB &= ~(1 << 5); } } DcsBios::IntegerBuffer clC1Buffer(0x10d4, 0x0100, 8, onClC1Change);
+void onClC2Change(unsigned int newValue) { if (newValue == 1) { PORTB |= (1 << 6); } else { PORTB &= ~(1 << 6); } } DcsBios::IntegerBuffer clC2Buffer(0x10d4, 0x0200, 9, onClC2Change);
+void onClC3Change(unsigned int newValue) { if (newValue == 1) { PORTJ |= (1 << 1); } else { PORTJ &= ~(1 << 1); } } DcsBios::IntegerBuffer clC3Buffer(0x10d4, 0x0400, 10, onClC3Change);
+void onClC4Change(unsigned int newValue) { if (newValue == 1) { PORTJ |= (1 << 0); } else { PORTJ &= ~(1 << 0); } } DcsBios::IntegerBuffer clC4Buffer(0x10d4, 0x0800, 11, onClC4Change);
+void onClD1Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 1); } else { PORTH &= ~(1 << 1); } } DcsBios::IntegerBuffer clD1Buffer(0x10d4, 0x1000, 12, onClD1Change);
+void onClD2Change(unsigned int newValue) { if (newValue == 1) { PORTH |= (1 << 0); } else { PORTH &= ~(1 << 0); } } DcsBios::IntegerBuffer clD2Buffer(0x10d4, 0x2000, 13, onClD2Change);
+void onClD3Change(unsigned int newValue) { if (newValue == 1) { PORTD |= (1 << 3); } else { PORTD &= ~(1 << 3); } } DcsBios::IntegerBuffer clD3Buffer(0x10d4, 0x4000, 14, onClD3Change);
+void onClD4Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 0); } else { PORTF &= ~(1 << 0); } } DcsBios::IntegerBuffer clD4Buffer(0x10d4, 0x8000, 15, onClD4Change);
+void onClE1Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 1); } else { PORTF &= ~(1 << 1); } } DcsBios::IntegerBuffer clE1Buffer(0x10d6, 0x0001, 0, onClE1Change);
+void onClE2Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 2); } else { PORTF &= ~(1 << 2); } } DcsBios::IntegerBuffer clE2Buffer(0x10d6, 0x0002, 1, onClE2Change);
+void onClE3Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 3); } else { PORTF &= ~(1 << 3); } } DcsBios::IntegerBuffer clE3Buffer(0x10d6, 0x0004, 2, onClE3Change);
+void onClE4Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 4); } else { PORTF &= ~(1 << 4); } } DcsBios::IntegerBuffer clE4Buffer(0x10d6, 0x0008, 3, onClE4Change);
+void onClF1Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 5); } else { PORTF &= ~(1 << 5); } } DcsBios::IntegerBuffer clF1Buffer(0x10d6, 0x0010, 4, onClF1Change);
+void onClF2Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 6); } else { PORTF &= ~(1 << 6); } } DcsBios::IntegerBuffer clF2Buffer(0x10d6, 0x0020, 5, onClF2Change);
+void onClF3Change(unsigned int newValue) { if (newValue == 1) { PORTF |= (1 << 7); } else { PORTF &= ~(1 << 7); } } DcsBios::IntegerBuffer clF3Buffer(0x10d6, 0x0040, 6, onClF3Change);
+void onClF4Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 0); } else { PORTK &= ~(1 << 0); } } DcsBios::IntegerBuffer clF4Buffer(0x10d6, 0x0080, 7, onClF4Change);
+void onClG1Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 1); } else { PORTK &= ~(1 << 1); } } DcsBios::IntegerBuffer clG1Buffer(0x10d6, 0x0100, 8, onClG1Change);
+void onClG2Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 2); } else { PORTK &= ~(1 << 2); } } DcsBios::IntegerBuffer clG2Buffer(0x10d6, 0x0200, 9, onClG2Change);
+void onClG3Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 3); } else { PORTK &= ~(1 << 3); } } DcsBios::IntegerBuffer clG3Buffer(0x10d6, 0x0400, 10, onClG3Change);
+void onClG4Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 4); } else { PORTK &= ~(1 << 4); } } DcsBios::IntegerBuffer clG4Buffer(0x10d6, 0x0800, 11, onClG4Change);
+void onClH1Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 5); } else { PORTK &= ~(1 << 5); } } DcsBios::IntegerBuffer clH1Buffer(0x10d6, 0x1000, 12, onClH1Change);
+void onClH2Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 6); } else { PORTK &= ~(1 << 6); } } DcsBios::IntegerBuffer clH2Buffer(0x10d6, 0x2000, 13, onClH2Change);
+void onClH3Change(unsigned int newValue) { if (newValue == 1) { PORTK |= (1 << 7); } else { PORTK &= ~(1 << 7); } } DcsBios::IntegerBuffer clH3Buffer(0x10d6, 0x4000, 14, onClH3Change);
+void onClH4Change(unsigned int newValue) { if (newValue == 1) { PORTD |= (1 << 2); } else { PORTD &= ~(1 << 2); } } DcsBios::IntegerBuffer clH4Buffer(0x10d6, 0x8000, 15, onClH4Change);
+void onClI1Change(unsigned int newValue) { if (newValue == 1) { PORTD |= (1 << 1); } else { PORTD &= ~(1 << 1); } } DcsBios::IntegerBuffer clI1Buffer(0x10d8, 0x0001, 0, onClI1Change);
+void onClI2Change(unsigned int newValue) { if (newValue == 1) { PORTD |= (1 << 0); } else { PORTD &= ~(1 << 0); } } DcsBios::IntegerBuffer clI2Buffer(0x10d8, 0x0002, 1, onClI2Change);
+void onClI3Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 0); } else { PORTA &= ~(1 << 0); } } DcsBios::IntegerBuffer clI3Buffer(0x10d8, 0x0004, 2, onClI3Change);
+void onClI4Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 1); } else { PORTA &= ~(1 << 1); } } DcsBios::IntegerBuffer clI4Buffer(0x10d8, 0x0008, 3, onClI4Change);
+void onClJ1Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 2); } else { PORTA &= ~(1 << 2); } } DcsBios::IntegerBuffer clJ1Buffer(0x10d8, 0x0010, 4, onClJ1Change);
+void onClJ2Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 3); } else { PORTA &= ~(1 << 3); } } DcsBios::IntegerBuffer clJ2Buffer(0x10d8, 0x0020, 5, onClJ2Change);
+void onClJ3Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 4); } else { PORTA &= ~(1 << 4); } } DcsBios::IntegerBuffer clJ3Buffer(0x10d8, 0x0040, 6, onClJ3Change);
+void onClJ4Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 5); } else { PORTA &= ~(1 << 5); } } DcsBios::IntegerBuffer clJ4Buffer(0x10d8, 0x0080, 7, onClJ4Change);
+void onClK1Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 6); } else { PORTA &= ~(1 << 6); } } DcsBios::IntegerBuffer clK1Buffer(0x10d8, 0x0100, 8, onClK1Change);
+void onClK2Change(unsigned int newValue) { if (newValue == 1) { PORTA |= (1 << 7); } else { PORTA &= ~(1 << 7); } } DcsBios::IntegerBuffer clK2Buffer(0x10d8, 0x0200, 9, onClK2Change);
+void onClK3Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 7); } else { PORTC &= ~(1 << 7); } } DcsBios::IntegerBuffer clK3Buffer(0x10d8, 0x0400, 10, onClK3Change);
+void onClK4Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 6); } else { PORTC &= ~(1 << 6); } } DcsBios::IntegerBuffer clK4Buffer(0x10d8, 0x0800, 11, onClK4Change);
+void onClL1Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 5); } else { PORTC &= ~(1 << 5); } } DcsBios::IntegerBuffer clL1Buffer(0x10d8, 0x1000, 12, onClL1Change);
+void onClL2Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 4); } else { PORTC &= ~(1 << 4); } } DcsBios::IntegerBuffer clL2Buffer(0x10d8, 0x2000, 13, onClL2Change);
+void onClL3Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 3); } else { PORTC &= ~(1 << 3); } } DcsBios::IntegerBuffer clL3Buffer(0x10d8, 0x4000, 14, onClL3Change);
+void onClL4Change(unsigned int newValue) { if (newValue == 1) { PORTC |= (1 << 2); } else { PORTC &= ~(1 << 2); } } DcsBios::IntegerBuffer clL4Buffer(0x10d8, 0x8000, 15, onClL4Change);
+
+void setup() {
+  DcsBios::setup();
+}
+
+void loop() {
+  DcsBios::loop();
+}

--- a/src/DcsBios.h
+++ b/src/DcsBios.h
@@ -14,6 +14,7 @@
 #include "internal/ExportStreamListener.h"
 #include "internal/PollingInput.h"
 #include "internal/Protocol.h"
+#include "internal/Protocol.cpp.inc"
 #include "internal/Addresses.h"
 
 

--- a/src/DcsBios.h
+++ b/src/DcsBios.h
@@ -14,7 +14,7 @@
 #include "internal/ExportStreamListener.h"
 #include "internal/PollingInput.h"
 #include "internal/Protocol.h"
-#include "internal/Protocol.cpp.inc"
+#include "internal/Protocol.cpp.inc" // Needs to be a .cpp.inc to allow DCSBIOS_INCOMING_DATA_BUFFER_SIZE
 #include "internal/Addresses.h"
 
 

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -243,11 +243,13 @@ namespace DcsBios {
 		PollingInput::pollInputs();
 		ExportStreamListener::loopAll();
 
+		#ifdef DCSBIOS_ALTERNATIVE_RS485_PROCESSING
 		// Process incoming data outside of ISR
 		if (!parser.incomingDataBuffer.isEmpty()) {
 			unsigned char nextByte = parser.incomingDataBuffer.get();
 			parser.processChar(nextByte);
 		}
+		#endif
 	}
 }
 #endif

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -247,10 +247,12 @@ namespace DcsBios {
 		ExportStreamListener::loopAll();
 
 		// Process incoming data outside of ISR
+		#ifdef DCSBIOS_DEFER_RS485_PROCESSING
 		if (!parser.incomingDataBuffer.isEmpty()) {
 			unsigned char nextByte = parser.incomingDataBuffer.get();
 			parser.processChar(nextByte);
 		}
+		#endif
 	}
 }
 #endif

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -107,7 +107,7 @@ namespace DcsBios {
 			case RX_WAIT_DATA:
 				rxtx_len--;
 				if (rx_datatype == RXDATA_DCSBIOS_EXPORT) {
-					if (rxtx_len <= parser.availableBufferSpace()) {
+					if (rxtx_len <= parser.incomingDataBuffer.availableForWrite()) {
 						parser.processCharISR(c);
 					}
 				}

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -109,6 +109,9 @@ namespace DcsBios {
 				if (rx_datatype == RXDATA_DCSBIOS_EXPORT) {
 					if (rxtx_len <= parser.incomingDataBuffer.availableForWrite()) {
 						parser.processCharISR(c);
+					} else {
+						last_rx_time = micros();
+						state = SYNC;
 					}
 				}
 				if (rxtx_len == 0) {

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -107,10 +107,7 @@ namespace DcsBios {
 			case RX_WAIT_DATA:
 				rxtx_len--;
 				if (rx_datatype == RXDATA_DCSBIOS_EXPORT) {
-					if (rxtx_len > parser.availableBufferSpace()) {
-						// Toggle D13 LED to indicate buffer overflow
-						PORTB ^= (1<<7);
-					} else {
+					if (rxtx_len <= parser.availableBufferSpace()) {
 						parser.processCharISR(c);
 					}
 				}
@@ -246,6 +243,7 @@ namespace DcsBios {
 		PollingInput::pollInputs();
 		ExportStreamListener::loopAll();
 
+		// Process incoming data outside of ISR
 		if (!parser.incomingDataBuffer.isEmpty()) {
 			unsigned char nextByte = parser.incomingDataBuffer.get();
 			parser.processChar(nextByte);

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -107,7 +107,12 @@ namespace DcsBios {
 			case RX_WAIT_DATA:
 				rxtx_len--;
 				if (rx_datatype == RXDATA_DCSBIOS_EXPORT) {
-					parser.processCharISR(c);
+					if (rxtx_len > parser.availableBufferSpace()) {
+						// Toggle D13 LED to indicate buffer overflow
+						PORTB ^= (1<<7);
+					} else {
+						parser.processCharISR(c);
+					}
 				}
 				if (rxtx_len == 0) {
 					state = RX_WAIT_CHECKSUM;
@@ -240,6 +245,11 @@ namespace DcsBios {
 	void loop() {
 		PollingInput::pollInputs();
 		ExportStreamListener::loopAll();
+
+		if (!parser.incomingDataBuffer.isEmpty()) {
+			unsigned char nextByte = parser.incomingDataBuffer.get();
+			parser.processChar(nextByte);
+		}
 	}
 }
 #endif

--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -243,13 +243,11 @@ namespace DcsBios {
 		PollingInput::pollInputs();
 		ExportStreamListener::loopAll();
 
-		#ifdef DCSBIOS_ALTERNATIVE_RS485_PROCESSING
 		// Process incoming data outside of ISR
 		if (!parser.incomingDataBuffer.isEmpty()) {
 			unsigned char nextByte = parser.incomingDataBuffer.get();
 			parser.processChar(nextByte);
 		}
-		#endif
 	}
 }
 #endif

--- a/src/internal/Protocol.cpp
+++ b/src/internal/Protocol.cpp
@@ -13,6 +13,10 @@ namespace DcsBios {
 		sync_byte_count = 0;
 	}
 
+	uint8_t ProtocolParser::availableBufferSpace() {
+		return incomingDataBuffer.availableForWrite();
+	}
+
 	/*
 		to be called from ISR
 		stores the character in a buffer, re-enables interrupts and processes the complete
@@ -20,7 +24,7 @@ namespace DcsBios {
 	*/
 	void ProtocolParser::processCharISR(unsigned char c) {
 		incomingDataBuffer.put(c);
-		if (processingData) return;
+		/*if (processingData) return;
 		
 		processingData = true;
 		while (1) {
@@ -34,7 +38,7 @@ namespace DcsBios {
 #ifdef DCSBIOS_RS485_SLAVE
 			noInterrupts();
 #endif
-		}
+		}*/
 	}
 	
 	void ProtocolParser::processChar(unsigned char c) {

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -22,7 +22,7 @@ namespace DcsBios {
 		incomingDataBuffer.put(c);
 
 		// For some reason RS485 slaves cannot process data here, while it works over USB. Perhaps due to the additonal overhead of the RS485 state machine? If DCSBIOS_RS485_SLAVE is defined, the processing is deferred to loop().
-		#ifndef DCSBIOS_RS485_SLAVE
+		#ifndef DCSBIOS_DEFER_RS485_PROCESSING
 		if (processingData) return;
 		
 		processingData = true;

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -38,6 +38,9 @@ namespace DcsBios {
 			unsigned char nextByte = incomingDataBuffer.get();
 			interrupts();
 			processChar(nextByte);
+#ifdef DCSBIOS_RS485_SLAVE
+			noInterrupts();
+#endif
 		}
 		#endif
 	}

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -26,7 +26,7 @@ namespace DcsBios {
 		incomingDataBuffer.put(c);
 
 		// For some reason RS485 slaves cannot process data here, while it works over USB. If DCSBIOS_RS485_SLAVE is defined, the processing is deferred to loop().
-		#ifndef DCSBIOS_RS485_SLAVE
+		#ifndef DCSBIOS_ALTERNATIVE_RS485_PROCESSING
 		if (processingData) return;
 		
 		processingData = true;

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -25,8 +25,8 @@ namespace DcsBios {
 	void ProtocolParser::processCharISR(unsigned char c) {
 		incomingDataBuffer.put(c);
 
-		// For some reason RS485 slaves cannot process data here, while it works over USB. If DCSBIOS_RS485_SLAVE is defined, the processing is deferred to loop().
-		#ifndef DCSBIOS_ALTERNATIVE_RS485_PROCESSING
+		// For some reason RS485 slaves cannot process data here, while it works over USB. Perhaps due to the additonal overhead of the RS485 state machine? If DCSBIOS_RS485_SLAVE is defined, the processing is deferred to loop().
+		#ifndef DCSBIOS_RS485_SLAVE
 		if (processingData) return;
 		
 		processingData = true;
@@ -38,9 +38,6 @@ namespace DcsBios {
 			unsigned char nextByte = incomingDataBuffer.get();
 			interrupts();
 			processChar(nextByte);
-#ifdef DCSBIOS_RS485_SLAVE
-			noInterrupts();
-#endif
 		}
 		#endif
 	}

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -24,7 +24,10 @@ namespace DcsBios {
 	*/
 	void ProtocolParser::processCharISR(unsigned char c) {
 		incomingDataBuffer.put(c);
-		/*if (processingData) return;
+
+		// For some reason RS485 slaves cannot process data here, while it works over USB. If DCSBIOS_RS485_SLAVE is defined, the processing is deferred to loop().
+		#ifndef DCSBIOS_RS485_SLAVE
+		if (processingData) return;
 		
 		processingData = true;
 		while (1) {
@@ -35,10 +38,8 @@ namespace DcsBios {
 			unsigned char nextByte = incomingDataBuffer.get();
 			interrupts();
 			processChar(nextByte);
-#ifdef DCSBIOS_RS485_SLAVE
-			noInterrupts();
-#endif
-		}*/
+		}
+		#endif
 	}
 	
 	void ProtocolParser::processChar(unsigned char c) {

--- a/src/internal/Protocol.cpp.inc
+++ b/src/internal/Protocol.cpp.inc
@@ -13,10 +13,6 @@ namespace DcsBios {
 		sync_byte_count = 0;
 	}
 
-	uint8_t ProtocolParser::availableBufferSpace() {
-		return incomingDataBuffer.availableForWrite();
-	}
-
 	/*
 		to be called from ISR
 		stores the character in a buffer, re-enables interrupts and processes the complete

--- a/src/internal/Protocol.h
+++ b/src/internal/Protocol.h
@@ -9,6 +9,10 @@
 #define DCSBIOS_STATE_DATA_LOW 5
 #define DCSBIOS_STATE_DATA_HIGH 6
 
+#ifndef DCSBIOS_INCOMING_DATA_BUFFER_SIZE
+#define DCSBIOS_INCOMING_DATA_BUFFER_SIZE 64
+#endif
+
 #include "ExportStreamListener.h"
 #include "RingBuffer.h"
 
@@ -25,7 +29,7 @@ namespace DcsBios {
 			ExportStreamListener* startESL;
 			volatile bool processingData;
 		public:
-			RingBuffer<64> incomingDataBuffer;
+			RingBuffer<DCSBIOS_INCOMING_DATA_BUFFER_SIZE> incomingDataBuffer;
 			void processChar(unsigned char c);
 			void processCharISR(unsigned char c);
 			uint8_t availableBufferSpace();

--- a/src/internal/Protocol.h
+++ b/src/internal/Protocol.h
@@ -23,11 +23,12 @@ namespace DcsBios {
 			volatile unsigned char sync_byte_count;
 			
 			ExportStreamListener* startESL;
-			RingBuffer<64> incomingDataBuffer;
 			volatile bool processingData;
 		public:
+			RingBuffer<64> incomingDataBuffer;
 			void processChar(unsigned char c);
 			void processCharISR(unsigned char c);
+			uint8_t availableBufferSpace();
 			ProtocolParser();
 	};
 }

--- a/src/internal/Protocol.h
+++ b/src/internal/Protocol.h
@@ -30,9 +30,9 @@ namespace DcsBios {
 			volatile bool processingData;
 		public:
 			RingBuffer<DCSBIOS_INCOMING_DATA_BUFFER_SIZE> incomingDataBuffer;
+			
 			void processChar(unsigned char c);
 			void processCharISR(unsigned char c);
-			uint8_t availableBufferSpace();
 			ProtocolParser();
 	};
 }

--- a/src/internal/RingBuffer.h
+++ b/src/internal/RingBuffer.h
@@ -16,6 +16,7 @@ namespace DcsBios {
 		__attribute__((always_inline)) uint8_t get() { uint8_t ret = buffer[readpos]; readpos = ++readpos % SIZE; return ret; }
 		__attribute__((always_inline)) uint8_t getLength() { return (uint8_t)(writepos - readpos) % SIZE; }
 		__attribute__((always_inline)) void clear() { readpos = 0; writepos = 0; }
+		__attribute__((always_inline)) uint8_t availableForWrite() { return SIZE - getLength() - 1; }
 	};
 }
 


### PR DESCRIPTION
## RS485 Data Dropping
This PR addresses the data dropping issues encountered when RS485 slaves are too busy to process incoming data.

## The problem
RS485 slaves drop incoming export data if the user sketch runs too slow. It happens when drawing to a slow display, but also in cases where it should work a lot faster, such as writing to a Nextion display (UART2, 250000 baud). Additionally, if you map 48LEDs on an Arduino Mega, even with [direct register writes](https://github.com/maciekish/warthogathome/blob/master/Arduino/23_Caution_Panel/23_Caution_Panel.ino), it triggers the same issue.

## Videos
These examples run on the **exact same** hardware, code **and** [data](https://github.com/DCS-Skunkworks/dcs-bios/tree/master/Programs/tools). The only difference are the `#defines` for USB or RS485 mode. I have made a dev-board for tracking down this particular issue, and it includes the same amount of LED as the A-10C Caution Panel, and a Nextion header for easy testing.

<img src="https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/a35f665a-d92b-460f-b900-02436fe35a92" width="240" height="200">

### Before
<details>
  <summary>Expand</summary>


https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/aa52dc19-75ec-43b5-9923-50d1c205e953


https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/8b70e117-7645-43d3-9224-e8cfed37ffae



</details>

### After
<details>
  <summary>Expand</summary>


https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/da5d1ab8-925a-4ef8-aaff-95fb7868c803


https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/a93be506-1f3b-4d3d-a5da-2a97d581068e



</details>

## Changes
I have done extensive testing and found the following changes fix the issue. Each change improves the situation, and together, RS485 slaves behave like USB devices.

1) Process incoming data outside of the ISR. `processCharISR()` has been modified to only store the received byte if `DCSBIOS_RS485_SLAVE` is defined. `processChar()` has been moved to `loop()`.
2) `unit8_t availableForWrite()` added to `RingBuffer`.
3) When receiving RS485 data, the `incomingDataBuffer` is checked for space to avoid a buffer overflow.
4) The size of `incomingDataBuffer` is user-configurable with `#define DCSBIOS_INCOMING_DATA_BUFFER_SIZE 512`.

## Rationale
1) Currently, all RS485 data processing happens in ISR context, in `processCharISR()`. This function directly calls out to individual ESLs, which in turn run all user code in any DCS-BIOS callbacks. In practice, pretty much the whole sketch runs in ISR context, with nested interrupts. There is barely any prioritization because everything runs from the ISR. So when new data arrives, it has to contest for resources. While it may seem like calling `processChar()` is important, the full picture must be considered. If `processChar()` takes a bit longer because it´s now called in `loop()` and may be interrupted, the only downside is that the external update (LED, display, servo etc) will happen **slightly** later. But if `processCharISR()` doesn't run fast enough, we start dropping data randomly, sync is invalidated because we don't know what, or how much was dropped, and the whole `incomingDataBuffer` becomes a mess.
2) If the user sketch is too slow, data will **have** to be dropped somewhere. With the current code, this happens inside the `incomingDataBuffer` which is a `RingBuffer`. What this means in practice, is that if an ESL is busy reading data from the `RingBuffer`, and an interrupt causes a write longer than available space, the new data will overwrite old data that hasn't been processed yet. This causes all sorts of weird issues, like the sync sequence `UUUU` appearing as text on displays, or the wrong LEDs lighting up/extinguishing on a caution panel. So, if the buffer cannot fit the new data, it **has** to be discarded.
3) Same as above.
4) The default size of 64 bytes may be enough for a couple LEDs, but when attempting to draw a CDU page, the amount of data is 10 lines x 24 characters = 240 bytes of raw data. On top of that, space for the address and sync sequence etc must be considered. With a 512 byte buffer and controlling a Nextion display over UART2 with HardwareSerial, only 20% RAM on an Arduino Mega is used. If not defined by the user, the default 64b buffer is retained.

## User impact
All changes only affect AVR MCUs in RS485 mode. USB mode is not affected. To enable the new processing mode, use `DCSBIOS_DEFER_RS485_PROCESSING`:

```
#define DCSBIOS_DEFER_RS485_PROCESSING
```