### PR TITLE
Added resetAllStates() to DcsBiosNgRS485Slave.cpp

### DIFF
--- a/src/internal/DcsBiosNgRS485Slave.cpp.inc
+++ b/src/internal/DcsBiosNgRS485Slave.cpp.inc
@@ -241,5 +241,9 @@ namespace DcsBios {
 		PollingInput::pollInputs();
 		ExportStreamListener::loopAll();
 	}
+
+	void resetAllStates() {
+		PollingInput::resetAllStates();
+	}
 }
 #endif


### PR DESCRIPTION
When compiling for RS485, the DcsBios::ResetAllStates() wrapper is missing. This PR adds the missing wrapper.

<img width="470" alt="image" src="https://github.com/DCS-Skunkworks/dcs-bios-arduino-library/assets/442007/0aaf1e3b-1721-4ff1-beb3-fd98705e65e0">
