### PR TITLE
Arduino Library Manager preparation

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
-name=DCS-BIOS FP-Fork
+name=DCS-BIOS-Skunkworks
 author=Puma (talbotmcinnis)
 maintainer=Jan B�cker, Warlord, Puma (talbotmcinnis)
 sentence=Connect input and output devices to the DCS: World flight simulator using DCS-BIOS.
 paragraph=DCS-BIOS is a piece of software that can extract data from DCS: World and sends them to an Arduino. It also accepts commands over the serial port. This library talks to DCS-BIOS and allows you to connect any component your Arduino can communicate with to your virtual cockpit.
-url=https://github.com/DCSFlightpanels/dcs-bios
+url=https://github.com/DCS-Skunkworks/dcs-bios
 category=Other
 version=0.3.9


### PR DESCRIPTION
Replaced FP-Fork with Skunkworks in name and URL, and replaced the space in the name with a dash according to [Arduino Library Manager](https://github.com/arduino/arduino-lint) recommendations.