### PR TITLE
Update name to avoid Skunkworks being duplicated

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=DCS-BIOS-Skunkworks
+name=DCS-BIOS
 author=Puma (talbotmcinnis)
 maintainer=Jan B�cker, Warlord, Puma (talbotmcinnis)
 sentence=Connect input and output devices to the DCS: World flight simulator using DCS-BIOS.


### PR DESCRIPTION
This doesn't look good, updated the libraryu name to be only DCS-BIOS

![image](https://github.com/user-attachments/assets/5e6a9dad-056b-442c-964e-cae8e2be2d67)