### PR TITLE
Added DcsBios.h to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,4 +5,6 @@ sentence=Connect input and output devices to the DCS: World flight simulator usi
 paragraph=DCS-BIOS is a piece of software that can extract data from DCS: World and sends them to an Arduino. It also accepts commands over the serial port. This library talks to DCS-BIOS and allows you to connect any component your Arduino can communicate with to your virtual cockpit.
 url=https://github.com/DCS-Skunkworks/dcs-bios
 category=Other
+headers=DcsBios.h
+includes=DcsBios.h
 version=0.3.9


### PR DESCRIPTION
This serves as guidance for Arduino IDE and PlatformIO to include the correct file in the project, otherwise for example PlatformIO Repository suggests #include <Addresses.h> which is incorrect. "includes" is for Arduino IDE and "headers" for PlatformIO. Without this change, PlatformIO suggests the following as the Installation step:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/f5972d7c-e3bf-438f-bd76-33e63f1b2ead">
